### PR TITLE
feat: add --add-tag and --remove-tag flags to link edit

### DIFF
--- a/crates/rott-cli/src/main.rs
+++ b/crates/rott-cli/src/main.rs
@@ -112,6 +112,12 @@ enum LinkCommands {
     Edit {
         /// Link ID (full UUID or prefix)
         id: String,
+        /// Add a tag (can be repeated)
+        #[arg(long = "add-tag")]
+        add_tags: Vec<String>,
+        /// Remove a tag (can be repeated)
+        #[arg(long = "remove-tag")]
+        remove_tags: Vec<String>,
     },
     /// Delete a link
     #[command(alias = "rm")]
@@ -297,7 +303,11 @@ async fn handle_link_command(
         LinkCommands::Create { url, tag } => commands::link::create(store, url, tag, output).await,
         LinkCommands::List { tag } => commands::link::list(store, tag, output),
         LinkCommands::Show { id } => commands::link::show(store, id, output),
-        LinkCommands::Edit { id } => commands::link::edit(store, id, output),
+        LinkCommands::Edit {
+            id,
+            add_tags,
+            remove_tags,
+        } => commands::link::edit(store, id, add_tags, remove_tags, output),
         LinkCommands::Delete { id } => commands::link::delete(store, id, output),
         LinkCommands::Search { query } => commands::link::search(store, query, output),
         LinkCommands::Note { command } => handle_note_command(command, store, output),


### PR DESCRIPTION
## Summary

Add non-interactive tag manipulation to `rott link edit` command.

## Changes

- Add `--add-tag <tag>` flag (can be repeated)
- Add `--remove-tag <tag>` flag (can be repeated)  
- When tag flags are provided, skip interactive editor and apply only tag changes
- Multiple operations can be combined in a single command

## Usage

```bash
# Add a tag
rott link edit <ID> --add-tag <tag>

# Remove a tag  
rott link edit <ID> --remove-tag <tag>

# Multiple operations
rott link edit <ID> --add-tag foo --remove-tag bar
```

## Testing

- All existing tests pass (139 tests)
- Manual verification of add/remove/combined operations

Closes #71